### PR TITLE
ci: update tfsec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   tfsec:
     name: Static Analysis
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout ${{ github.ref }} [${{ github.sha }}]
         uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
 
   validate:
     name: Validation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout ${{ github.ref }} [${{ github.sha }}]
         uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
 
   # drift:
   #   name: Drift Detection
-  #   runs-on: ubuntu-20.04
+  #   runs-on: ubuntu-24.04
   #   defaults:
   #     run:
   #       working-directory: core
@@ -110,7 +110,7 @@ jobs:
 
   # snyk:
   #   name: Snyk IaC
-  #   runs-on: ubuntu-20.04
+  #   runs-on: ubuntu-24.04
   #   steps:
   #     - name: Checkout ${{ github.ref }} [${{ github.sha }}]
   #       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,11 @@ jobs:
       - name: Run tfsec
         continue-on-error: true
         run: |
-          wget --no-verbose --show-progress --progress dot:giga https://github.com/aquasecurity/tfsec/releases/download/v1.26.3/tfsec-linux-amd64
-          echo "896872247843cc08d4c5b3b3362ca87e8939c2404c6ccb7415a523a114344224  tfsec-linux-amd64" | sha256sum -c
+          wget --no-verbose --show-progress --progress dot:giga https://github.com/aquasecurity/tfsec/releases/download/v1.28.11/tfsec-linux-amd64
+          echo "18e2f947a4f0ec74bf6db07245fc81f83930835ef1b5d51d2d5152a6548b5e45  tfsec-linux-amd64" | sha256sum -c
 
-          wget --no-verbose --show-progress --progress dot:giga https://github.com/aquasecurity/tfsec/releases/download/v1.26.3/tfsec-linux-amd64.D66B222A3EA4C25D5D1A097FC34ACEFB46EC39CE.sig
-          echo "971a7151ed435ee6f8cadea42c838addef92aa063ab66fda97eb063b66a14a15  tfsec-linux-amd64.D66B222A3EA4C25D5D1A097FC34ACEFB46EC39CE.sig" | sha256sum -c
+          wget --no-verbose --show-progress --progress dot:giga https://github.com/aquasecurity/tfsec/releases/download/v1.28.11/tfsec-linux-amd64.D66B222A3EA4C25D5D1A097FC34ACEFB46EC39CE.sig
+          echo "41a0b39f39aa860930aa3c7bddb140da433ba61bd4e445c76585e2afa8d4c772  tfsec-linux-amd64.D66B222A3EA4C25D5D1A097FC34ACEFB46EC39CE.sig" | sha256sum -c
 
           gpg --import < tfsec/tfsec.asc
           gpg --list-keys signing@tfsec.dev


### PR DESCRIPTION
This MR bumps `tfsec` from v1.26.3 to v1.28.11.